### PR TITLE
Updates to base.{hpp,cpp}, ConnectionString class

### DIFF
--- a/persist/src/page.cpp
+++ b/persist/src/page.cpp
@@ -29,6 +29,8 @@
 #include <persist/core/exceptions.hpp>
 #include <persist/core/page.hpp>
 
+#include <cstring>
+
 // ----------------------------------------------------------------------------
 // TODO:
 //  - Little and Big Eddien mismatch during serialization. Maybe this is not

--- a/persist/src/record_block.cpp
+++ b/persist/src/record_block.cpp
@@ -29,6 +29,8 @@
 #include <persist/core/exceptions.hpp>
 #include <persist/core/record_block.hpp>
 
+#include <cstring>
+
 namespace persist {
 
 // ----------------------------------------------------------------------------

--- a/persist/src/storage/base.cpp
+++ b/persist/src/storage/base.cpp
@@ -62,12 +62,7 @@ const std::unordered_map<std::string, StorageType> StorageTypeMap = {
  * TODO: Prase arguments like `pageSize`.
  */
 class ConnectionString {
-  PERSIST_PRIVATE
-  /**
-   * Regex used for parsing the connection type
-   */  
-  static constexpr std::regex test_rx("(\\w+)(?:\\:\\/{2})([\\/A-z=0-9\\.]+)(?:\\?)([&A-z=0-9]+)+"); 
-  std::smatch sm{};  
+  PERSIST_PRIVATE 
 
 public:  
   std::string type;
@@ -75,12 +70,15 @@ public:
   std::string args;
 
   // Constructor
-  ConnectionString(std::string connectionString) : raw(connectionString) {
+  ConnectionString(std::string connectionString) 
+  : type{}, path{}, args{} {
   
-    std::regex_match(connectionString, test_rx, sm);
+    std::regex test_rx{"(\\w+)(?:\\:\\/{2})([\\/A-z=0-9\\.]+)(?:\\?)([&A-z=0-9]+)+"};
+    std::smatch sm{}; 
+    std::regex_match(connectionString, sm, test_rx);
     type = sm.str(1);
-    path = sm.str(2) };
-    args = sm.str(3) };
+    path = sm.str(2);
+    args = sm.str(3);
   }
 };
 

--- a/persist/src/storage/base.cpp
+++ b/persist/src/storage/base.cpp
@@ -78,6 +78,10 @@ public:
     std::regex_match(connectionString, sm, test_rx);
     type = sm.str(1);
     path = sm.str(2);
+    /**
+    * TODO: args is currently in the form <arg_1=val_1&arg_2=val_2>.  Another 
+    * regex will be needed to split them into arg value pairs.
+    */
     args = sm.str(3);
   }
 };

--- a/persist/src/storage/base.cpp
+++ b/persist/src/storage/base.cpp
@@ -30,6 +30,8 @@
 #include <persist/core/storage/file_storage.hpp>
 #include <persist/core/storage/memory_storage.hpp>
 
+#include <regex>
+
 namespace persist {
 
 /**
@@ -62,27 +64,29 @@ const std::unordered_map<std::string, StorageType> StorageTypeMap = {
 class ConnectionString {
   PERSIST_PRIVATE
   /**
-   * Storage type seperator in connection string
-   */
-  static const std::string storageTypeSep;
+   * Regex used for parsing the connection type
+   */  
+  static constexpr std::regex test_rx("(\\w+)(?:\\:\\/{2})([\\/A-z=0-9\\.]+)(?:\\?)([&A-z=0-9]+)+"); 
+  std::smatch sm{};  
 
-public:
-  std::string raw;
+public:  
   std::string type;
   std::string path;
+  std::string args;
 
   // Constructor
   ConnectionString(std::string connectionString) : raw(connectionString) {
-    std::string::size_type loc = raw.find(storageTypeSep);
-    type = raw.substr(0, loc);
-    path = raw.substr(loc + storageTypeSep.size());
+  
+    std::regex_match(connectionString, test_rx, sm);
+    type = sm.str(1);
+    path = sm.str(2) };
+    args = sm.str(3) };
   }
 };
 
-const std::string ConnectionString::storageTypeSep = "://";
-
 std::unique_ptr<Storage> Storage::create(std::string connectionString) {
   ConnectionString _connectionString(connectionString);
+  
 
   switch (StorageTypeMap.at(_connectionString.type)) {
   case StorageType::FILE:


### PR DESCRIPTION
Here's a first attempt at implementing the file regex for the ConnectionString class.  There's a few .cpp files that needed <cstring> for std::memcpy on g++/linux.